### PR TITLE
Splitting classifyInputString() into two parts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${DCD_CXX_FLAGS})
 add_executable(txid2txref txid2txref.cpp t2tSupport.cpp t2tSupport.h bitcoinRPCFacade.cpp bitcoinRPCFacade.h txid2txref.h)
 target_link_libraries(txid2txref libtxref libbech32 anyoption ${JSONCPP_LIBRARIES} ${BITCOINAPICPP_LIBRARIES})
 
-add_executable(createBtcrDid createBtcrDid.cpp t2tSupport.cpp t2tSupport.h bitcoinRPCFacade.cpp bitcoinRPCFacade.h chainQuery.h chainSoQuery.cpp chainSoQuery.h CurlWrapper.cpp CurlWrapper.h encodeOpReturnData.h satoshis.h classifyInputString.h)
+add_executable(createBtcrDid createBtcrDid.cpp t2tSupport.cpp t2tSupport.h bitcoinRPCFacade.cpp bitcoinRPCFacade.h chainQuery.h chainSoQuery.cpp chainSoQuery.h CurlWrapper.cpp CurlWrapper.h encodeOpReturnData.h satoshis.h classifyInputString.h classifyInputString.cpp)
 target_link_libraries(createBtcrDid libtxref libbech32 anyoption ${JSONCPP_LIBRARIES} ${BITCOINAPICPP_LIBRARIES} ${CURL_LIBRARIES})
 
 install(TARGETS txid2txref createBtcrDid DESTINATION bin)

--- a/src/classifyInputString.cpp
+++ b/src/classifyInputString.cpp
@@ -1,0 +1,81 @@
+#include "classifyInputString.h"
+
+namespace {
+
+    InputParam classifyInputStringBase(const std::string & str) {
+
+        if(str.empty())
+            return unknown_param;
+
+        // if exactly 64 chars in length, it is likely a transaction id
+        if(str.length() == 64)
+            return txid_param;
+
+        // if it starts with certain chars, and is of a certain length, it may be a bitcoin address
+        if(str[0] == '1' || str[0] == '3' || str[0] == 'm' || str[0] == 'n' || str[0] == '2')
+            if(str.length() >= 26 && str.length() < 36)
+                return address_param;
+
+        // before testing for various txrefs, get rid of any unknown characters
+        std::string s = bech32::stripUnknownChars(str);
+
+        using namespace txref::limits;
+
+        // may be be txref (with leading HRP)
+        if(s.length() == TXREF_STRING_MIN_LENGTH ||
+           s.length() == TXREF_STRING_MIN_LENGTH_TESTNET)
+            return txref_param;
+
+        // may be be txrefext (with leading HRP)
+        if(s.length() == TXREF_EXT_STRING_MIN_LENGTH ||
+           s.length() == TXREF_EXT_STRING_MIN_LENGTH_TESTNET)
+            return txrefext_param;
+
+        return unknown_param;
+    }
+
+    InputParam classifyInputStringMissingHRP(const std::string & str) {
+
+        // before testing for various txrefs, get rid of any unknown characters
+        std::string s = bech32::stripUnknownChars(str);
+
+        using namespace txref::limits;
+
+        // may be be txref (without leading HRP)
+        if(s.length() == TXREF_STRING_NO_HRP_MIN_LENGTH ||
+           s.length() == TXREF_STRING_NO_HRP_MIN_LENGTH_TESTNET)
+            return txref_param;
+
+        // may be be txrefext (without leading HRP)
+        if(s.length() == TXREF_EXT_STRING_NO_HRP_MIN_LENGTH ||
+           s.length() == TXREF_EXT_STRING_NO_HRP_MIN_LENGTH_TESTNET)
+            return txrefext_param;
+
+        return unknown_param;
+    }
+
+}
+
+InputParam classifyInputString(const std::string & str) {
+
+    InputParam baseResult = classifyInputStringBase(str);
+    InputParam missingResult = classifyInputStringMissingHRP(str);
+
+    // if one result is 'unknown' and the other isn't, then return the good one
+    if(baseResult != unknown_param && missingResult == unknown_param)
+        return baseResult;
+    if(baseResult == unknown_param && missingResult != unknown_param)
+        return missingResult;
+
+    // special case: if baseResult is 'txref' and the other is 'txrefext' then we need to dig
+    // deeper as mainnet min txref with HRP is same length as mainnet min txrefext without HRP
+    if (baseResult == txref_param && missingResult == txrefext_param) {
+        if (str[0] == 't' && str[1] == 'x' && str[2] == '1')
+            return txref_param;
+        else
+            return txrefext_param;
+    }
+
+    // otherwise, just return (should be unknown)
+    return baseResult;
+}

--- a/src/classifyInputString.h
+++ b/src/classifyInputString.h
@@ -11,46 +11,6 @@ enum InputParam { unknown_param, address_param, txid_param, txref_param, txrefex
 // This function will determine if the input string is a Bitcoin address, txid,
 // txref, or txrefext_param. This is not meant to be an exhaustive test--should only be
 // used as a first pass to see what sort of string might be passed in as input.
-inline InputParam classifyInputString(const std::string & str) {
-
-    if(str.empty())
-        return unknown_param;
-
-    // if exactly 64 chars in length, it is likely a transaction id
-    if(str.length() == 64)
-        return txid_param;
-
-    // if it starts with certain chars, and is of a certain length, it may be a bitcoin address
-    if(str[0] == '1' || str[0] == '3' || str[0] == 'm' || str[0] == 'n' || str[0] == '2')
-        if(str.length() >= 26 && str.length() < 36)
-            return address_param;
-
-    std::string s = bech32::stripUnknownChars(str);
-
-    using namespace txref::limits;
-
-    // may be be txref (with or without leading HRP)
-    if(s.length() == TXREF_STRING_NO_HRP_MIN_LENGTH ||
-       s.length() == TXREF_STRING_MIN_LENGTH_TESTNET ||
-       s.length() == TXREF_STRING_NO_HRP_MIN_LENGTH_TESTNET)
-        return txref_param;
-
-    // may be be txrefext (with or without leading HRP)
-    if(s.length() == TXREF_EXT_STRING_MIN_LENGTH ||
-       s.length() == TXREF_EXT_STRING_MIN_LENGTH_TESTNET ||
-       s.length() == TXREF_EXT_STRING_NO_HRP_MIN_LENGTH_TESTNET)
-        return txrefext_param;
-
-    // special case: mainnet min txref with HRP is same length as mainnet min txrefext without HRP
-    if(s.length() == TXREF_STRING_MIN_LENGTH ||
-       s.length() == TXREF_EXT_STRING_NO_HRP_MIN_LENGTH ) {
-        if (s[0] == 't' && s[1] == 'x' && s[2] == '1')
-            return txref_param;
-        else
-            return txrefext_param;
-    }
-
-    return unknown_param;
-}
+InputParam classifyInputString(const std::string & str);
 
 #endif //TXREF_CLASSIFYINPUTSTRING_H

--- a/test/test_classifyInputString.cpp
+++ b/test/test_classifyInputString.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "classifyInputString.h"
+#include "classifyInputString.cpp"
 
 
 TEST(ClassifyInputStringTest, test_empty) {
@@ -18,6 +19,20 @@ TEST(ClassifyInputStringTest, test_address) {
     EXPECT_EQ(classifyInputString("mzgjzyj9i9JyU5zBQyNBZMkm2QNz2MQ3Se"), address_param);
     EXPECT_EQ(classifyInputString("mxgj4vFNNWPdRb45tHoJoVqfahYkc3QYZ4"), address_param);
     EXPECT_EQ(classifyInputString("mxgj4vFNNWPdRb45tHoJoVqfahYk8ec3QYZ4"), unknown_param);
+}
+
+TEST(ClassifyInputStringTest, test_bad_address) {
+    EXPECT_EQ(classifyInputString("17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhemse"), unknown_param);
+    EXPECT_EQ(classifyInputString("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQXdd"), unknown_param);
+    EXPECT_EQ(classifyInputString("2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vcd"), unknown_param);
+    EXPECT_EQ(classifyInputString("mzgjzyj9i9JyU5zBQyNBZMkm2QNz2MQ3Sedd"), unknown_param);
+    EXPECT_EQ(classifyInputString("mxgj4vFNNWPdRb45tHoJoVqfahYkc3QYZ4dd"), unknown_param);
+    EXPECT_EQ(classifyInputString("mxgj4vFNNWPdRb45tHoJoVqfahYk8ec3QYZ4"), unknown_param);
+    EXPECT_EQ(classifyInputString("17VZNX1SN5NtKa8UQFxwQbFeF"), unknown_param);
+    EXPECT_EQ(classifyInputString("3EktnHQD7RiAE6uzMj2ZffT9Y"), unknown_param);
+    EXPECT_EQ(classifyInputString("2MzQwSSnBHWHqSAqtTVQ6v47X"), unknown_param);
+    EXPECT_EQ(classifyInputString("mzgjzyj9i9JyU5zBQyNBZMkm2"), unknown_param);
+    EXPECT_EQ(classifyInputString("mxgj4vFNNWPdRb45tHoJoVqfa"), unknown_param);
 }
 
 TEST(ClassifyInputStringTest, test_txid) {


### PR DESCRIPTION
These changes split classifyInputString() into two parts--one part that checks all the base cases needed to determine BTC addresses, txids and "spec" txrefs and txrefexts, and one part that checks the cases for txrefs and txrefexts which are missing HRPs, that we will propose for the btcr DID method.