### PR TITLE
update bitcoinRPCFacade to reflect recent RPC method changes in bitcoind 0.18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ available:
 
 ```
 $ ./src/txid2txref --help
-Usage: txid2txref [options] <txid>
+Usage: txid2txref [options] <txid|txref>
 
  -h  --help                 Print this help
  --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1)

--- a/src/bitcoinRPCFacade.h
+++ b/src/bitcoinRPCFacade.h
@@ -13,7 +13,6 @@ struct getrawtransaction_t;
 struct blockinfo_t;
 struct utxoinfo_t;
 struct txout_t;
-struct signrawtxin_t;
 
 // struct for local impl of getblockchaininfo()
 struct blockchaininfo_t {
@@ -30,6 +29,16 @@ struct blockchaininfo_t {
     //std::vector<...> softforks;
     //std::vector<...> bip9_softforks;
 };
+
+// struct for local impl of signrawtxin_t
+struct signrawtxinext_t {
+    std::string txid;
+    unsigned int n;
+    std::string scriptPubKey;
+    std::string redeemScript;
+    std::string amount;
+};
+
 
 struct RpcConfig {
     std::string rpcuser = "";
@@ -60,15 +69,15 @@ public:
     virtual std::string createrawtransaction(const std::vector<txout_t>& inputs, const std::map<std::string, double>& amounts) const;
     virtual std::string createrawtransaction(const std::vector<txout_t>& inputs, const std::map<std::string, std::string>& amounts) const;
 
-    virtual std::string signrawtransaction(const std::string& rawTx, const std::vector<signrawtxin_t> & inputs, const std::vector<std::string>& privkeys, const std::string& sighashtype) const;
-
-    std::string sendrawtransaction(const std::string& hexString, bool highFee=false) const;
-
     // implement missing bitcoinapi functions
     virtual blockchaininfo_t getblockchaininfo() const;
+    virtual std::string signrawtransactionwithkey(const std::string& rawTx, const std::vector<signrawtxinext_t> & inputs, const std::vector<std::string>& privkeys, const std::string& sighashtype) const;
+
+    // re-implement out-of-date bitcoinapi functions
+    virtual std::string sendrawtransaction(const std::string& hexString) const;
 
 protected:
-    BitcoinRPCFacade() {}
+    BitcoinRPCFacade() = default;
 };
 
 

--- a/src/createBtcrDid.cpp
+++ b/src/createBtcrDid.cpp
@@ -284,14 +284,15 @@ int main(int argc, char *argv[]) {
         std::string rawTransaction = btc.createrawtransaction(inputs, amounts);
 
         // sign with private key
-        signrawtxin_t signrawtxin;
+        signrawtxinext_t signrawtxin;
         signrawtxin.txid = unspentData.txid;
         signrawtxin.n = static_cast<unsigned int>(unspentData.utxoIndex);
         signrawtxin.scriptPubKey = unspentData.scriptPubKeyHex;
         signrawtxin.redeemScript = "";
+        signrawtxin.amount = std::to_string(satoshi2btc(unspentData.amountSatoshis));
 
         std::string signedRawTransaction =
-                btc.signrawtransaction(rawTransaction, {signrawtxin}, {transactionData.privateKey}, "ALL");
+                btc.signrawtransactionwithkey(rawTransaction, {signrawtxin}, {transactionData.privateKey}, "ALL");
 
         if(signedRawTransaction.empty()) {
             std::cerr << "Error: transaction could not be signed. Check your private key." << std::endl;

--- a/test/mock_bitcoinRPCFacade.h
+++ b/test/mock_bitcoinRPCFacade.h
@@ -21,8 +21,8 @@ public:
             std::string(const std::vector<txout_t>& inputs, const std::map<std::string, double>& amounts));
     MOCK_CONST_METHOD2(createrawtransaction,
             std::string(const std::vector<txout_t>& inputs, const std::map<std::string, std::string>& amounts));
-    MOCK_CONST_METHOD4(signrawtransaction,
-            std::string(const std::string& rawTx, const std::vector<signrawtxin_t> & inputs, const std::vector<std::string>& privkeys, const std::string& sighashtype));
+    MOCK_CONST_METHOD4(signrawtransactionwithkey,
+                       std::string(const std::string& rawTx, const std::vector<signrawtxinext_t> & inputs, const std::vector<std::string>& privkeys, const std::string& sighashtype));
     MOCK_CONST_METHOD0(getblockchaininfo,
             blockchaininfo_t());
     virtual ~MockBitcoinRPCFacade();


### PR DESCRIPTION
The bitcoin-api-cpp library we are using is getting out of date, and the maintainer isn't merging PRs he's been getting (including an older one I sent). So, I have been implementing missing functions and re-implementing one that was broken in our wrapper class, BitcoinRPCFacade.