### PR TITLE
Add block 0 special case and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ ./src/txid2txref --help
 Usage: txid2txref [options] <txid|txref>
 
  -h  --help                 Print this help
- --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1)
+ --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1)
  --rpcuser [user]           RPC user
  --rpcpassword [pass]       RPC password
  --rpcport [port]           RPC port (default: try both 8332 and 18332)
@@ -170,7 +170,7 @@ bitcoind over RPC. There are four `--rpc*` options that you can use for
 connecting to a local or remote bitcoind:
 
 ```
-$ ./src/txid2txref --rpcuser bitcoinrpc --rpcpassword super-secret-passwd --rpchost 127.0.0.1 --rpcport 18332 <txid>
+$ ./src/txid2txref --rpcuser bitcoinrpc --rpcpassword super-secret-passwd --rpcconnect 127.0.0.1 --rpcport 18332 <txid>
 {...}
 ```
 
@@ -251,7 +251,7 @@ options available:
 Usage: createBtcrDid [options] <inputXXX> <outputAddress> <private key> <fee> <ddoRef>
 
  -h  --help                 Print this help
- --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1)
+ --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1)
  --rpcuser [user]           RPC user
  --rpcpassword [pass]       RPC password
  --rpcport [port]           RPC port (default: try both 8332 and 18332)
@@ -270,7 +270,7 @@ bitcoind over RPC. There are four `--rpc*` options that you can use for
 connecting to a local or remote bitcoind:
 
 ```
-$ ./src/createBtcrDid --rpcuser bitcoinrpc --rpcpassword super-secret-passwd --rpchost 127.0.0.1 --rpcport 18332 ...
+$ ./src/createBtcrDid --rpcuser bitcoinrpc --rpcpassword super-secret-passwd --rpcconnect 127.0.0.1 --rpcport 18332 ...
 ```
 
 If you have bitcoind running locally, you probably have a bitcoin.conf

--- a/integration/CMakeLists.txt
+++ b/integration/CMakeLists.txt
@@ -118,6 +118,16 @@ set_tests_properties("IntegrationTests_t2t_txid_from_txrefext_bad_txoIndex" PROP
         PASS_REGULAR_EXPRESSION "Warning: txoIndex '3' was ignored"
         FAIL_REGULAR_EXPRESSION "Error")
 
+# make sure we return correct network for a txref
+
+add_test(NAME "IntegrationTests_t2t_check_network_mismatch_for_txref"
+        COMMAND $<TARGET_FILE:txid2txref> tx1:rqqq‑qqqq‑qwtv‑vjr)
+set_tests_properties("IntegrationTests_t2t_check_network_mismatch_for_txref" PROPERTIES
+        PASS_REGULAR_EXPRESSION "will not be found in your bitcoind")
+
+# check special case for txid 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+
+
 ############################################################
 # Integration tests for createBtcrDid
 

--- a/integration/CMakeLists.txt
+++ b/integration/CMakeLists.txt
@@ -125,8 +125,6 @@ add_test(NAME "IntegrationTests_t2t_check_network_mismatch_for_txref"
 set_tests_properties("IntegrationTests_t2t_check_network_mismatch_for_txref" PROPERTIES
         PASS_REGULAR_EXPRESSION "will not be found in your bitcoind")
 
-# check special case for txid 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
-
 
 ############################################################
 # Integration tests for createBtcrDid

--- a/src/bitcoinRPCFacade.cpp
+++ b/src/bitcoinRPCFacade.cpp
@@ -7,6 +7,11 @@ namespace {
     int MAINNET_PORT = 8332;
     int TESTNET_PORT = 18332;
 
+    // blockhash for block 0 can be found with "bitcoin-cli getblockhash 0"
+    char block_0_hash[] = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+    // hex for transaction 0 can be found with "bitcoin-cli getblock 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f 2 | jq '.tx[0].hex'"
+    char block_0_tx_0_hex[] = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000";
+
     bool isConnectionGood(BitcoinAPI *b) {
         try {
             b->getblockcount();
@@ -47,9 +52,19 @@ getrawtransaction_t BitcoinRPCFacade::getrawtransaction(const std::string &txid,
     if(txid != "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
         return bitcoinAPI->getrawtransaction(txid, verbose);
     else {
+        // if we are not on mainnet, just call out to the api
+        blockchaininfo_t blockChainInfo = getblockchaininfo();
+        if(blockChainInfo.chain != "main")
+            return bitcoinAPI->getrawtransaction(txid, verbose);
+
+        // mainnet genesis transaction 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+        // can not be retrieved from bitcoind, so we will fake it here just enough to allow callers of
+        // getrawtransaction() to work with it.
         getrawtransaction_t tx;
-        // just need blockhash and vout?...
-        return bitcoinAPI->getrawtransaction(txid, verbose);
+        tx.blockhash = block_0_hash;
+        tx.hex = block_0_tx_0_hex;
+        tx.vout.resize(1);
+        return tx;
     }
 }
 

--- a/src/bitcoinRPCFacade.cpp
+++ b/src/bitcoinRPCFacade.cpp
@@ -24,19 +24,19 @@ BitcoinRPCFacade::BitcoinRPCFacade(
 
     std::stringstream ss;
     if(config.rpcport != 0) {
-        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpchost, config.rpcport);
+        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpcconnect, config.rpcport);
         if (isConnectionGood(bitcoinAPI))
             return;
-        ss << "Error: Can't connect to " << config.rpchost << " on port " << config.rpcport;
+        ss << "Error: Can't connect to " << config.rpcconnect << " on port " << config.rpcport;
     }
     else {
-        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpchost, MAINNET_PORT);
+        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpcconnect, MAINNET_PORT);
         if (isConnectionGood(bitcoinAPI))
             return;
-        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpchost, TESTNET_PORT);
+        bitcoinAPI = new BitcoinAPI(config.rpcuser, config.rpcpassword, config.rpcconnect, TESTNET_PORT);
         if (isConnectionGood(bitcoinAPI))
             return;
-        ss << "Error: Can't connect to " << config.rpchost << " on either port (" << MAINNET_PORT << "," << TESTNET_PORT << ")";
+        ss << "Error: Can't connect to " << config.rpcconnect << " on either port (" << MAINNET_PORT << "," << TESTNET_PORT << ")";
     }
     throw std::runtime_error(ss.str());
 }
@@ -44,7 +44,13 @@ BitcoinRPCFacade::BitcoinRPCFacade(
 BitcoinRPCFacade::~BitcoinRPCFacade() = default;
 
 getrawtransaction_t BitcoinRPCFacade::getrawtransaction(const std::string &txid, int verbose) const {
-    return bitcoinAPI->getrawtransaction(txid, verbose);
+    if(txid != "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+        return bitcoinAPI->getrawtransaction(txid, verbose);
+    else {
+        getrawtransaction_t tx;
+        // just need blockhash and vout?...
+        return bitcoinAPI->getrawtransaction(txid, verbose);
+    }
 }
 
 blockinfo_t BitcoinRPCFacade::getblock(const std::string &blockhash) const {

--- a/src/bitcoinRPCFacade.h
+++ b/src/bitcoinRPCFacade.h
@@ -73,7 +73,7 @@ struct btcaddressinfo_t { // not using addressinfo_t as that is already used in 
 struct RpcConfig {
     std::string rpcuser = "";
     std::string rpcpassword ="";
-    std::string rpchost = "127.0.0.1";
+    std::string rpcconnect = "127.0.0.1";
     int rpcport = 0;
 };
 

--- a/src/createBtcrDid.cpp
+++ b/src/createBtcrDid.cpp
@@ -133,7 +133,7 @@ int parseCommandLineArgs(int argc, char **argv,
     opt->addUsage( "Usage: createBtcrDid [options] <inputXXX> <outputAddress> <private key> <fee> <ddoRef>" );
     opt->addUsage( "" );
     opt->addUsage( " -h  --help                 Print this help " );
-    opt->addUsage( " --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1) " );
+    opt->addUsage( " --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1) " );
     opt->addUsage( " --rpcuser [user]           RPC user " );
     opt->addUsage( " --rpcpassword [pass]       RPC password " );
     opt->addUsage( " --rpcport [port]           RPC port (default: try both 8332 and 18332) " );
@@ -149,7 +149,7 @@ int parseCommandLineArgs(int argc, char **argv,
 
     opt->setFlag("help", 'h');
     opt->setFlag("dryrun", 'n');
-    opt->setOption("rpchost");
+    opt->setOption("rpcconnect");
     opt->setOption("rpcuser");
     opt->setOption("rpcpassword");
     opt->setOption("rpcport");
@@ -196,9 +196,9 @@ int parseCommandLineArgs(int argc, char **argv,
         cmdlineInput.dryrun = true;
     }
 
-    // see if there is an rpchost specified. If not, use default
-    if (opt->getValue("rpchost") != nullptr) {
-        rpcConfig.rpchost = opt->getValue("rpchost");
+    // see if there is an rpcconnect specified. If not, use default
+    if (opt->getValue("rpcconnect") != nullptr) {
+        rpcConfig.rpcconnect = opt->getValue("rpcconnect");
     }
 
     // see if there is an rpcuser specified. If not, exit

--- a/src/didResolver.cpp
+++ b/src/didResolver.cpp
@@ -64,7 +64,7 @@ int parseCommandLineArgs(int argc, char **argv,
     opt->addUsage( "Usage: didResolver [options] <did>" );
     opt->addUsage( "" );
     opt->addUsage( " -h  --help                 Print this help " );
-    opt->addUsage( " --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1) " );
+    opt->addUsage( " --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1) " );
     opt->addUsage( " --rpcuser [user]           RPC user " );
     opt->addUsage( " --rpcpassword [pass]       RPC password " );
     opt->addUsage( " --rpcport [port]           RPC port (default: try both 8332 and 18332) " );
@@ -73,7 +73,7 @@ int parseCommandLineArgs(int argc, char **argv,
     opt->addUsage( "<did>                       the BTCR DID to resolve. Could be txref or txref-ext based" );
 
     opt->setFlag("help", 'h');
-    opt->setOption("rpchost");
+    opt->setOption("rpcconnect");
     opt->setOption("rpcuser");
     opt->setOption("rpcpassword");
     opt->setOption("rpcport");
@@ -119,9 +119,9 @@ int parseCommandLineArgs(int argc, char **argv,
         return 0;
     }
 
-    // see if there is an rpchost specified. If not, use default
-    if (opt->getValue("rpchost") != nullptr) {
-        rpcConfig.rpchost = opt->getValue("rpchost");
+    // see if there is an rpcconnect specified. If not, use default
+    if (opt->getValue("rpcconnect") != nullptr) {
+        rpcConfig.rpcconnect = opt->getValue("rpcconnect");
     }
 
     // see if there is an rpcuser specified. If not, exit

--- a/src/didVerifier.cpp
+++ b/src/didVerifier.cpp
@@ -55,7 +55,7 @@ int parseCommandLineArgs(int argc, char **argv, struct RpcConfig &config, struct
     opt->addUsage( "Usage: createBtcrDid [options] <inputXXX> <changeAddress> <network> <WIF> <fee> <ddoRef>" );
     opt->addUsage( "" );
     opt->addUsage( " -h  --help                 Print this help " );
-    opt->addUsage( " --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1) " );
+    opt->addUsage( " --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1) " );
     opt->addUsage( " --rpcuser [user]           RPC user " );
     opt->addUsage( " --rpcpassword [pass]       RPC password " );
     opt->addUsage( " --rpcport [port]           RPC port (default: try both 8332 and 18332) " );
@@ -64,7 +64,7 @@ int parseCommandLineArgs(int argc, char **argv, struct RpcConfig &config, struct
     opt->addUsage( "<did>                       the BTCR DID to verify. Could be txref or txref-ext based" );
 
     opt->setFlag("help", 'h');
-    opt->setOption("rpchost");
+    opt->setOption("rpcconnect");
     opt->setOption("rpcuser");
     opt->setOption("rpcpassword");
     opt->setOption("rpcport");
@@ -106,9 +106,9 @@ int parseCommandLineArgs(int argc, char **argv, struct RpcConfig &config, struct
         return 0;
     }
 
-    // see if there is an rpchost specified. If not, use default
-    if (opt->getValue("rpchost") != nullptr) {
-        config.rpchost = opt->getValue("rpchost");
+    // see if there is an rpcconnect specified. If not, use default
+    if (opt->getValue("rpcconnect") != nullptr) {
+        config.rpcconnect = opt->getValue("rpcconnect");
     }
 
     // see if there is an rpcuser specified. If not, exit

--- a/src/t2tSupport.cpp
+++ b/src/t2tSupport.cpp
@@ -21,6 +21,7 @@ namespace t2t {
 
         // determine what network we are on
         bool isTestnet = blockChainInfo.chain == "test";
+        bool isRegtest = blockChainInfo.chain == "regtest";
 
         // use txid to call getrawtransaction to find the blockhash
         getrawtransaction_t rawTransaction = btc.getrawtransaction(txid, 1);
@@ -64,6 +65,9 @@ namespace t2t {
         std::string txref;
         if (isTestnet) {
             txref = txref::encodeTestnet(
+                    blockHeight, static_cast<int>(blockIndex), txoIndex, false);
+        } else if (isRegtest) {
+            txref = txref::encodeRegtest(
                     blockHeight, static_cast<int>(blockIndex), txoIndex, false);
         } else {
             txref = txref::encode(

--- a/src/t2tSupport.cpp
+++ b/src/t2tSupport.cpp
@@ -8,6 +8,13 @@
 
 namespace t2t {
 
+    bool isNetworkMismatch(const std::string & hrp, const std::string & networkName) {
+        return
+                !((hrp == txref::BECH32_HRP_MAIN && networkName == "main") ||
+                (hrp == txref::BECH32_HRP_TEST && networkName == "test") ||
+                (hrp == txref::BECH32_HRP_REGTEST && networkName == "regtest"));
+    }
+
     void encodeTxid(const BitcoinRPCFacade & btc, const std::string & txid, int txoIndex, struct Transaction & transaction) {
 
         blockchaininfo_t blockChainInfo = btc.getblockchaininfo();
@@ -78,6 +85,13 @@ namespace t2t {
         txref::DecodedResult decodedResult = txref::decode(txref);
 
         blockchaininfo_t blockChainInfo = btc.getblockchaininfo();
+
+        if(isNetworkMismatch(decodedResult.hrp, blockChainInfo.chain)) {
+            std::cerr << "Error: txref '" << txref
+                      << "' will not be found in your bitcoind which is configured for the "
+                      << blockChainInfo.chain << " network." << std::endl;
+            std::exit(-1);
+        }
 
         // get block hash for block
         std::string blockHash = btc.getblockhash(decodedResult.blockHeight);

--- a/src/t2tSupport.h
+++ b/src/t2tSupport.h
@@ -6,6 +6,8 @@
 
 namespace t2t {
 
+    bool isNetworkMismatch(const std::string& hrp, const std::string& networkName);
+
     void encodeTxid(const BitcoinRPCFacade & btc, const std::string & txid, int txoIndex, struct Transaction & transaction);
 
     void decodeTxref(const BitcoinRPCFacade & btc, const std::string & txid, struct Transaction & transaction);

--- a/src/txid2txref.cpp
+++ b/src/txid2txref.cpp
@@ -81,7 +81,7 @@ int parseCommandLineArgs(int argc, char **argv,
     opt->addUsage( "Usage: txid2txref [options] <txid|txref>" );
     opt->addUsage( "" );
     opt->addUsage( " -h  --help                 Print this help " );
-    opt->addUsage( " --rpchost [rpchost or IP]  RPC host (default: 127.0.0.1) " );
+    opt->addUsage( " --rpcconnect [hostname or IP]  RPC host (default: 127.0.0.1) " );
     opt->addUsage( " --rpcuser [user]           RPC user " );
     opt->addUsage( " --rpcpassword [pass]       RPC password " );
     opt->addUsage( " --rpcport [port]           RPC port (default: try both 8332 and 18332) " );
@@ -91,7 +91,7 @@ int parseCommandLineArgs(int argc, char **argv,
     opt->addUsage( "<txid|txref>                input: can be a txid to encode, or a txref to decode" );
 
     opt->setFlag("help", 'h');
-    opt->setOption("rpchost");
+    opt->setOption("rpcconnect");
     opt->setOption("rpcuser");
     opt->setOption("rpcpassword");
     opt->setOption("rpcport");
@@ -133,9 +133,9 @@ int parseCommandLineArgs(int argc, char **argv,
         return 0;
     }
 
-    // see if there is an rpchost specified. If not, use default
-    if (opt->getValue("rpchost") != nullptr) {
-        rpcConfig.rpchost = opt->getValue("rpchost");
+    // see if there is an rpcconnect specified. If not, use default
+    if (opt->getValue("rpcconnect") != nullptr) {
+        rpcConfig.rpcconnect = opt->getValue("rpcconnect");
     }
 
     // see if there is an rpcuser specified. If not, exit


### PR DESCRIPTION
Added code to deal with someone asking for a txref for "mainnet block 0, tx 0" which is not a valid tx that can be requested from bitcoind.
Also updated a configuration parameter to match bitcoin.conf (changed rpchost to rpcconnect) and improved error message if someone tried to decode a txref from a different network than bitcoind is configured for. 